### PR TITLE
Sheldon Can Detect Broken Symlinks

### DIFF
--- a/lib/sheldon/brain.rb
+++ b/lib/sheldon/brain.rb
@@ -29,7 +29,8 @@ class Brain
     entry = memory.recall(recall_cue)
     destination_path = add_home(entry[:filepath])
     destination_dir = File.dirname(destination_path)
-    File.symlink?(destination_path)
+    # Check for presence of symlink and that the symlink isn't broken
+    File.symlink?(destination_path) && File.exists?(File.readlink(destination_path))
   end
 
   def has_cue?(recall_cue)

--- a/spec/sheldon/brain_spec.rb
+++ b/spec/sheldon/brain_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "byebug"
 
 describe Brain do
 
@@ -63,6 +64,17 @@ describe Brain do
     context "for a file that has not been recalled" do
       it "should return false" do
         brain.learn("my git config", abs_learn_path)
+        expect(brain.recalled?("my git config")).to be false
+      end
+    end
+
+    context "for a broken symlink" do
+      it "should return false" do
+        brain.learn("my git config", abs_learn_path)
+        brain.recall("my git config")
+        FileUtils.rm("spec/Users/test/sheldon/my git config/.gitconfig")
+        expect(File.symlink?("spec/Users/test/.gitconfig")).to be true
+        expect(File.exists?("spec/Users/test/sheldon/my git config/.gitconfig")).to be false
         expect(brain.recalled?("my git config")).to be false
       end
     end

--- a/spec/sheldon/brain_spec.rb
+++ b/spec/sheldon/brain_spec.rb
@@ -73,7 +73,7 @@ describe Brain do
         brain.learn("my git config", abs_learn_path)
         brain.recall("my git config")
         FileUtils.rm("spec/Users/test/sheldon/my git config/.gitconfig")
-        expect(File.symlink?("spec/Users/test/.gitconfig")).to be true
+        expect(File.symlink?(abs_learn_path)).to be true
         expect(File.exists?("spec/Users/test/sheldon/my git config/.gitconfig")).to be false
         expect(brain.recalled?("my git config")).to be false
       end


### PR DESCRIPTION
This PR fixes issue #13 - Broken symlinks will no longer be considered "recalled" by Sheldon.