### PR TITLE
Support file/directory overwrites via Sheldon#recall

### DIFF
--- a/bin/sheldon
+++ b/bin/sheldon
@@ -66,12 +66,12 @@ module CLI
 
       if options[:i]
         cue_options.each do |recall_cue|
-          answer = prompt.yes?("Recall #{recall_cue}?")
-          with_exception_handling { sheldon.recall(recall_cue) if answer == true }
+          recall_confirmed = prompt.yes?("Recall #{recall_cue}?")
+          perform_recall(recall_cue) if recall_confirmed
         end
       else
         recall_cue ||= cue_picker("What would you like to recall?", cue_options)
-        with_exception_handling { sheldon.recall(recall_cue) }
+        perform_recall(recall_cue)
         prompt.ok("Sheldon recall complete: #{recall_cue}")
       end
     end

--- a/bin/sheldon
+++ b/bin/sheldon
@@ -106,8 +106,15 @@ module CLI
       exit!
     end
 
-    def prompt
-      @prompt ||= TTY::Prompt.new(interrupt: :exit)
+    def perform_recall(recall_cue)
+      with_exception_handling do
+        begin
+          sheldon.recall(recall_cue)
+        rescue DestinationNotEmptyException => e
+          overwrite_confirmed = prompt.yes?("File/target already exists. Overwrite?")
+          sheldon.recall(recall_cue, overwrite: true) if overwrite_confirmed
+        end
+      end
     end
 
     def cue_picker(message, options=sheldon.list_cues)

--- a/bin/sheldon
+++ b/bin/sheldon
@@ -101,6 +101,10 @@ module CLI
 
     private
 
+    def cue_picker(message, options=sheldon.list_cues)
+      prompt.select(message, options, per_page: 20, filter: true)
+    end
+
     def error_and_exit(message)
       prompt.error(message)
       exit!
@@ -117,8 +121,8 @@ module CLI
       end
     end
 
-    def cue_picker(message, options=sheldon.list_cues)
-      prompt.select(message, options, per_page: 20, filter: true)
+    def prompt
+      @prompt ||= TTY::Prompt.new(interrupt: :exit)
     end
 
     def read_from_dotfile(key)

--- a/lib/sheldon/brain.rb
+++ b/lib/sheldon/brain.rb
@@ -47,15 +47,16 @@ class Brain
     memory.present?
   end
 
-  def recall(recall_cue)
+  def recall(recall_cue, opts={})
     entry = memory.recall(recall_cue)
     destination_path = add_home(entry[:filepath])
     destination_dir = File.dirname(destination_path)
-    raise DestinationNotEmptyException, "#{destination_path} already exists." if File.exist?(destination_path)
+
+    raise DestinationNotEmptyException, "#{destination_path} already exists." if File.exist?(destination_path) && !opts[:overwrite]
 
     FileUtils.mkdir_p(destination_dir) unless File.directory?(destination_dir)
     brain_path = brain_directory_for_cue(recall_cue)
-    FileUtils.ln_s(get_content(brain_path), destination_path)
+    FileUtils.ln_s(get_content(brain_path), destination_path, force: opts[:overwrite])
     return true
   end
 

--- a/lib/sheldon/sheldon.rb
+++ b/lib/sheldon/sheldon.rb
@@ -29,8 +29,8 @@ class Sheldon
     brain.list_cues
   end
 
-  def recall(recall_cue)
-    brain.recall(recall_cue)
+  def recall(recall_cue, opts={})
+    brain.recall(recall_cue, opts)
   end
 
   def setup!

--- a/lib/sheldon/sheldon.rb
+++ b/lib/sheldon/sheldon.rb
@@ -1,7 +1,7 @@
 require "fileutils"
 
 class Sheldon
-  VERSION = "6.1.1".freeze
+  VERSION = "6.2.0".freeze
   attr_reader :brain, :builder
 
   def initialize(sheldon_data_dir)

--- a/spec/sheldon/brain_spec.rb
+++ b/spec/sheldon/brain_spec.rb
@@ -50,10 +50,20 @@ describe Brain do
 
   describe "#recall" do
     context "when recalling a file that already exists on the host" do
-      it "should raise a runtime exception" do
-        brain.learn("my git config", abs_learn_path)
-        FileUtils.touch(abs_learn_path)
-        expect { brain.recall("my git config") }.to raise_error(DestinationNotEmptyException)
+      context "when the overwrite argument hasn't been set" do
+        it "should raise a runtime exception" do
+          brain.learn("my git config", abs_learn_path)
+          FileUtils.touch(abs_learn_path)
+          expect { brain.recall("my git config") }.to raise_error(DestinationNotEmptyException)
+        end
+      end
+
+      context "when the overwrite argument has been set" do
+        it "should successfully symlink the file to the destination directory" do
+          brain.learn("my git config", abs_learn_path)
+          FileUtils.touch(abs_learn_path)
+          expect(brain.recall("my git config", overwrite: true)).to be true
+        end
       end
     end
 


### PR DESCRIPTION
Release Sheldon 6.2.0

This release adds support for overwriting existing files or directories
via Sheldon#recall.

This improved recall functionality allows CLI users to optionally
overwrite existing files or directories with the contents of Sheldon's
data directory, should they desire.

Fixes issue #30