### PR TITLE
🐛 Handle broken symlinks during Sheldon#recall

### DIFF
--- a/lib/sheldon/brain.rb
+++ b/lib/sheldon/brain.rb
@@ -55,7 +55,7 @@ class Brain
     destination_dir = File.dirname(destination_path)
 
     # Handle the destination file / directory already existing on the filesystem
-    if File.exist?(destination_path)
+    if File.exist?(destination_path) || File.symlink?(destination_path)
       if opts[:overwrite]
         FileUtils.remove_dir(destination_path) # this (badly named) method deletes both files and folders
       else

--- a/lib/sheldon/sheldon.rb
+++ b/lib/sheldon/sheldon.rb
@@ -1,7 +1,7 @@
 require "fileutils"
 
 class Sheldon
-  VERSION = "6.2.1".freeze
+  VERSION = "6.2.2".freeze
   attr_reader :brain, :builder
 
   def initialize(sheldon_data_dir)

--- a/spec/sheldon/brain_spec.rb
+++ b/spec/sheldon/brain_spec.rb
@@ -69,6 +69,26 @@ describe Brain do
       end
     end
 
+    context "when recalling a file that exists as a broken symlink on the host" do
+      before(:each) do
+        brain.learn("my git config", abs_learn_path)
+        FileUtils.ln_s(abs_learn_path, abs_learn_path, force: true)
+      end
+      context "when the overwrite argument hasn't been set" do
+
+        it "should raise a runtime exception" do
+          expect { brain.recall("my git config") }.to raise_error(DestinationNotEmptyException)
+        end
+      end
+
+      context "when the overwrite argument has been set" do
+        it "should replace the broken symlink with the recalled file content" do
+          brain.recall("my git config", overwrite: true)
+          expect(File.read(abs_learn_path)).to eq("git file content")
+        end
+      end
+    end
+
     context "when recalling a folder that already exists on the host" do
       context "when the overwrite argument hasn't been set" do
         it "should raise a runtime exception" do


### PR DESCRIPTION
This commit avoids a `File exists @ syserr_fail2` error when trying to
recall a cue to a filepath occupied by a (broken) symlink. In this
scenario, `File.exist?(symlink_path)` will return `false` (since the
symlink is broken), though attempting to write a file to `symlink_path`
still raises a runtime exception.